### PR TITLE
Request update for NotoSansBuginese.glyphs

### DIFF
--- a/sources/NotoSansBuginese.glyphs
+++ b/sources/NotoSansBuginese.glyphs
@@ -2538,7 +2538,7 @@ nodes = (
 }
 );
 vertWidth = 0;
-width = 760;
+width = 666;
 }
 );
 unicode = 1A1A;

--- a/sources/NotoSansBuginese.glyphs
+++ b/sources/NotoSansBuginese.glyphs
@@ -2538,7 +2538,7 @@ nodes = (
 }
 );
 vertWidth = 0;
-width = 540;
+width = 760;
 }
 );
 unicode = 1A1A;


### PR DESCRIPTION
Increase U+1A1A ⎸ᨚ⎹ width to 666. The glyph width is not wide enough, overlap to the next glyph.

![ᨒᨚᨈᨑ](https://github.com/user-attachments/assets/ad63d77d-dd83-4c3b-aeb1-07e300433992)